### PR TITLE
feat(config): support production mysql

### DIFF
--- a/templates/mysql.yml
+++ b/templates/mysql.yml
@@ -1,6 +1,6 @@
 test:
     adapter: mysql2
-    encoding: utf8
+    encoding: utf8mb4
     database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
     username: <%= ENV['WERCKER_MYSQL_USERNAME'] %>
     password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>

--- a/templates/mysql.yml
+++ b/templates/mysql.yml
@@ -1,6 +1,6 @@
 test:
     adapter: mysql2
-    encoding: <%= ENV['WERCKER_MYSQL_ENCORDING'] %>
+    encoding: <%= ENV['WERCKER_MYSQL_ENCORDING'] || 'utf8' %>
     database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
     username: <%= ENV['WERCKER_MYSQL_USERNAME'] %>
     password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>

--- a/templates/mysql.yml
+++ b/templates/mysql.yml
@@ -1,6 +1,6 @@
 test:
     adapter: mysql2
-    encoding: utf8mb4
+    encoding: <%= ENV['WERCKER_MYSQL_ENCORDING'] %>
     database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
     username: <%= ENV['WERCKER_MYSQL_USERNAME'] %>
     password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>

--- a/templates/mysql.yml
+++ b/templates/mysql.yml
@@ -6,3 +6,6 @@ test:
     password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>
     host: <%= ENV['WERCKER_MYSQL_HOST'] %>
     port: <%= ENV['WERCKER_MYSQL_PORT'] %>
+
+production:
+  <<: *test

--- a/templates/mysql.yml
+++ b/templates/mysql.yml
@@ -1,11 +1,15 @@
-test:
+base: &base
     adapter: mysql2
     encoding: <%= ENV['WERCKER_MYSQL_ENCORDING'] || 'utf8' %>
-    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %>
     username: <%= ENV['WERCKER_MYSQL_USERNAME'] %>
     password: <%= ENV['WERCKER_MYSQL_PASSWORD'] %>
     host: <%= ENV['WERCKER_MYSQL_HOST'] %>
     port: <%= ENV['WERCKER_MYSQL_PORT'] %>
 
+test:
+    <<: *base
+    database: <%= ENV['WERCKER_MYSQL_DATABASE'] %><%= ENV['TEST_ENV_NUMBER'] %>
+
 production:
-  <<: *test
+    <<: *base

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: rails-database-yml
-version: 1.0.0
+version: 1.0.3
 description: rails-database-yml step

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: rails-database-yml
-version: 1.0.2
+version: 1.0.0
 description: rails-database-yml step


### PR DESCRIPTION
we define `production` on mysql since we want to execute rake task as RAILS_ENV=production on wercker.
## TODOs
- [x] use production on mysql
- [x] support `utf8mb4` encoding on mysql
- [x] reset version since we public like as repro/rails-database-yml on wercker step
